### PR TITLE
[issue/15]: Improved check condition for API version

### DIFF
--- a/app/modules/base.py
+++ b/app/modules/base.py
@@ -70,8 +70,8 @@ def validate_configs(configs):
     if not (configs.port >= 1024 and configs.port <= 65535):
         return False, "Invalid port number."
 
-    if configs.api_version not in range(1, 21):
-        return False, "Invalid API version."
+    if configs.api_version not in range(14, 21):
+        return False, "Minimum API version not met."
 
     if configs.search_timeout <= 0:
         return False, "Invalid searching timeout value."

--- a/app/modules/rundeck.py
+++ b/app/modules/rundeck.py
@@ -423,7 +423,7 @@ class RundeckApi(object):
                     stats_total += int(data)
 
         msg = 'Global statistics: {0} old executions deleted.'.format(stats_total)
-        self._log.write(msg, 3)
+        self._log.write(msg, 2)
 
         return True, ''
 


### PR DESCRIPTION
Fixes #15. Highest Rundeck API endpoint requires version 14, so this is the minimum API version that target Rundeck must have.